### PR TITLE
feat: HTTPサーバーを追加

### DIFF
--- a/Interstellar.Server/Program.cs
+++ b/Interstellar.Server/Program.cs
@@ -4,7 +4,7 @@
     {
         static void Main(string[] args)
         {
-            string urlPrefix = "ws://";
+            string urlPrefix = "http://";
             if(args.Length > 1)
             {
                 for(int i = 1; i < args.Length; i++)
@@ -12,7 +12,7 @@
                     switch(args[i])
                     {
                         case "-secure":
-                            urlPrefix = "wss://";
+                            urlPrefix = "https://";
                             break;
                     }
                 }

--- a/Interstellar.Server/Server.cs
+++ b/Interstellar.Server/Server.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 using WebSocketSharp.Server;
@@ -12,11 +13,59 @@ internal class Server
 {
     static public void StartServer(string url)
     {
-        var server = new WebSocketServer(url);
+        var http = new HttpServer(url);
 
-        server.AddWebSocketService<VCClientService>("/vc");
+        // --- HTTP ハンドラ ---
+        http.OnGet += (sender, e) =>
+        {
+            Console.WriteLine("HTTP request: " + e.Request.Url.AbsolutePath);
+            var req = e.Request;
+            var res = e.Response;
+            var path = req.Url.AbsolutePath;
 
-        server.Start();
+            string body;
+            string contentType = "text/plain; charset=utf-8";
+            int status = 200;
+
+            if (path == "/" )
+            {
+                contentType = "text/html; charset=utf-8";
+                body = "<!doctype html><meta charset='utf-8'><h1>Interstellar is working.</h1>";
+            }
+            else if (path == "/health")
+            {
+                contentType = "application/json; charset=utf-8";
+                body = "{\"status\":\"ok\"}";
+            }
+            else if (path == "/vc")
+            {
+                // WebSocket専用エンドポイントにHTTPで来たときの案内
+                status = 426; // Upgrade Required
+                res.Headers.Add("Upgrade", "websocket");
+                body = "This endpoint is WebSocket only. Use wss://.../vc";
+            }
+            else
+            {
+                status = 404;
+                body = "Not Found";
+            }
+
+            res.StatusCode = status;
+            res.ContentType = contentType;
+            res.ContentEncoding = Encoding.UTF8;
+            var buf = Encoding.UTF8.GetBytes(body);
+            res.ContentLength64 = buf.LongLength;
+            using (var os = res.OutputStream) { os.Write(buf, 0, buf.Length); }
+        };
+
+        // --- WebSocket /vc を登録 ---
+        http.AddWebSocketService<VCClientService>("/vc");
+
+        // 任意の調整
+        http.KeepClean = true;
+        http.WaitTime = TimeSpan.FromSeconds(30);
+
+        http.Start();
 
         ManualResetEvent exitEvent = new(false);
         Console.WriteLine("Press ctrl-c to exit.");


### PR DESCRIPTION
- Interstellarが動いているのかをHTTPで確認できるよう、/ (plain text) と /health (json) の2つのエンドポイントを追加しました。
- WebSocketsではない通常のHTTPリクエストが/vc宛に来た場合、ステータス426とともにplain textを返却するようにしました。