### PR TITLE
GitHubアクションによるプロジェクト自動ビルドをサポート

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: .NET Multi-Platform Build
+
+on:
+  push:
+    branches: ["**"]  # 匹配所有分支
+
+jobs:
+  build:
+
+    strategy:
+      matrix:
+        include:
+          - runs-on: ubuntu-latest
+            target-os: linux-x64
+          - runs-on: windows-latest
+            target-os: win-x64
+
+    runs-on: ${{ matrix.runs-on }}
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore --configuration Release
+    - name: Publish
+      run: dotnet publish --configuration Release --runtime ${{ matrix.target-os }} --self-contained true --output ./publish/${{ matrix.target-os }}
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: dotnet-build-${{ matrix.target-os }}
+        path: ./publish/${{ matrix.target-os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,8 @@
-name: .NET Multi-Platform Build
+name: Build
 
 on:
   push:
-    branches: ["**"]  # 匹配所有分支
+    branches: ["**"]
 
 jobs:
   build:
@@ -24,11 +24,11 @@ jobs:
       with:
         dotnet-version: 8.0.x
     - name: Restore dependencies
-      run: dotnet restore
+      run: dotnet restore Interstellar.Server/Interstellar.Server.csproj
     - name: Build
-      run: dotnet build --no-restore --configuration Release
+      run: dotnet build Interstellar.Server/Interstellar.Server.csproj --no-restore --configuration Release
     - name: Publish
-      run: dotnet publish --configuration Release --runtime ${{ matrix.target-os }} --self-contained true --output ./publish/${{ matrix.target-os }}
+      run: dotnet publish Interstellar.Server/Interstellar.Server.csproj --configuration Release --runtime ${{ matrix.target-os }} --self-contained true --output ./publish/${{ matrix.target-os }}
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Build
       run: dotnet build Interstellar.Server/Interstellar.Server.csproj --no-restore --configuration Release
     - name: Publish
-      run: dotnet publish Interstellar.Server/Interstellar.Server.csproj --configuration Release --runtime ${{ matrix.target-os }} --self-contained true --output ./publish/${{ matrix.target-os }}
+      run: dotnet publish Interstellar.Server/Interstellar.Server.csproj --configuration Release --runtime ${{ matrix.target-os }} --output ./publish/${{ matrix.target-os }}
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
このPRは、GitHubワークフローファイルを追加します。このワークフローは、新しいコミットがリポジトリにプッシュされるたびにInterstellar.Serverを自動的にビルドし、ビルド成果物にはWindows版とLinux版が含まれます。  
この取り組みは、ソースコードからデプロイを希望するユーザーのプロセスを簡素化し、ビルド済みの成果物を直接ダウンロードできるようにすることを目的としています。  
参考例として、[私のリポジトリでの実行記録](https://github.com/QingFeng-awa/Interstellar/actions)をご覧いただけます。